### PR TITLE
added clearUrl method

### DIFF
--- a/src/android/WebIntent.java
+++ b/src/android/WebIntent.java
@@ -108,6 +108,18 @@ public class WebIntent extends CordovaPlugin {
                 //return new PluginResult(PluginResult.Status.OK, uri);
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, uri));
                 return true;
+            } else if (action.equals("clearUri")) {
+                if (args.length() != 0) {
+                    //return new PluginResult(PluginResult.Status.INVALID_ACTION);
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
+                    return false;
+                }
+
+                Intent i = ((CordovaActivity)this.cordova.getActivity()).getIntent();
+                i.setData(null);
+                //return new PluginResult(PluginResult.Status.OK, uri);
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
+                return true;
             } else if (action.equals("onNewIntent")) {
             	//save reference to the callback; will be called on "new intent" events
                 this.onNewIntentCallbackContext = callbackContext;

--- a/www/webintent.js
+++ b/www/webintent.js
@@ -33,6 +33,14 @@
         }, 'WebIntent', 'hasExtra', [params]);
     };
 
+    WebIntent.prototype.clearUri = function(success, fail) {
+        return cordova.exec(function(args) {
+            success(args);
+        }, function(args) {
+            fail(args);
+        }, 'WebIntent', 'clearUri', []);
+    };
+
     WebIntent.prototype.getUri = function(success, fail) {
         return cordova.exec(function(args) {
             success(args);


### PR DESCRIPTION
Sometimes it's useful to clearUri, otherwise getUri always returns the same url (for example when I do window.location.href="newView.html", getUri should not return initial Uri) 

This PR is similar to #49